### PR TITLE
GPCUP-177 | Set 410 pixels as the new default side rail width.

### DIFF
--- a/skin.json
+++ b/skin.json
@@ -35,7 +35,7 @@
 		],
 		"IsOfficialWiki": false,
 		"SideRailCollapseWidth": 1350,
-		"SideRailWidth": 310,
+		"SideRailWidth": 410,
 		"SiteAdSlots": [],
 		"SiteIdSlots": [],
 		"SiteJsSlots": [],


### PR DESCRIPTION
The default for this setting in Hydra was changed to 410 a long time.  This updates the skin.json to reflect that.

https://hydra.gamepedia.com/index.php?title=Special:WikiAllowedSettings&section=setting&action=edit&asid=687