### PR TITLE
GPUCP-196 | Remove background color from custom CodeEditor icons

### DIFF
--- a/css/hydra.css
+++ b/css/hydra.css
@@ -102,6 +102,13 @@ div.vectorTabs li a {
 	background-color: #000000;
 }
 
+/* Fix custom CodeEditor icons background */
+.oo-ui-iconElement-icon.oo-ui-icon-gotoLine,
+.oo-ui-iconElement-icon.oo-ui-icon-wrapping,
+.oo-ui-iconElement-icon.oo-ui-icon-pilcrow {
+	background-color: transparent;
+}
+
 .oo-ui-iconElement-icon.oo-ui-iconElement-noIcon {
 	opacity: 0 !important;
 }


### PR DESCRIPTION
This three icons are loaded by CodeEditor and they are black, and because of that they are displayed as black boxes. Let's remove background color behind them.

@Wikia/core-platform-team 