### PR TITLE
Add runtime styles to expose theme vars + sane defaults for flaggedrevs

### DIFF
--- a/HydraHooks.php
+++ b/HydraHooks.php
@@ -117,6 +117,7 @@ class HydraHooks {
 	public static function onSkinPreloadExistence(array &$titles, Skin $skin) {
 		$skin->getOutput()->addModuleStyles([
 			'skin.hydra.css',
+			'skins.hydra.runtime.styles',
 		]);
 
 		if (class_exists('MobileContext')) {

--- a/resources/flaggedrevs.scss
+++ b/resources/flaggedrevs.scss
@@ -1,0 +1,66 @@
+.flaggedrevs-unreviewed {
+	background-color: #330252;
+}
+
+.fr-pending-long2,
+.flaggedrevs-pending {
+	background-color: var(--themed-text-color);
+	border: 1px solid var(--themed-border-color);
+}
+
+.flaggedrevs-pending a,
+.flaggedrevs-pending a:visited {
+	color: var(--text-color--light);
+}
+
+.flaggedrevs-color-1 {
+	background-color: rgba(4, 1, 31, 0.3);
+}
+
+.flaggedrevs-color-0 {
+	background-color: #700045;
+}
+
+.fr-rating-option-0,
+.fr-rating-option-1,
+.fr-rating-option-2,
+.fr-rating-option-3 {
+	background-color: inherit;
+	color: var(--themed-text-color);
+
+	option {
+		color: var(--text-color--dark);
+	}
+}
+
+table.flaggedrevs_editnotice,
+table.flaggedrevs_viewnotice {
+	background-color: inherit;
+	border-color: var(--themed-link-color);
+}
+
+#mw-fr-stablediff {
+	background-color: inherit;
+}
+
+div.flaggedrevs_short_details,
+div.flaggedrevs_short {
+	background-color: var(--themed-page-background--secondary);
+	color: var(--themed-text-color);
+}
+
+div.flaggedrevs_preview {
+	background-color: #031b30;
+	color: var(--themed-text-color);
+}
+
+div.flaggedrevs_notice {
+	background-color: #3d0000;
+}
+
+table.flaggedrevs_editnotice,
+table.flaggedrevs_viewnotice,
+.flaggedrevs_reviewform {
+	background-color: var(--themed-page-background--secondary);
+	color: var(--themed-text-color);
+}

--- a/resources/flaggedrevs.scss
+++ b/resources/flaggedrevs.scss
@@ -1,10 +1,10 @@
 .flaggedrevs-unreviewed {
-	background-color: #330252;
+	background-color: var(--themed-page-background--secondary);
 }
 
 .fr-pending-long2,
 .flaggedrevs-pending {
-	background-color: var(--themed-text-color);
+	background-color: var(--themed-page-background--secondary);
 	border: 1px solid var(--themed-border-color);
 }
 

--- a/resources/hydra.runtime.scss
+++ b/resources/hydra.runtime.scss
@@ -1,0 +1,4 @@
+@import 'Oasis/resources/color';
+@import 'dist/oojs-ui/themes/fandom/theming/index';
+@import 'Oasis/resources/special-colors';
+@import 'dist/oojs-ui/themes/fandom/theming/colors-vars';

--- a/resources/index.scss
+++ b/resources/index.scss
@@ -1,0 +1,2 @@
+@import 'banner';
+@import 'flaggedrevs';

--- a/skin.json
+++ b/skin.json
@@ -157,6 +157,12 @@
 			"targets": [
 				"mobile"
 			]
+		},
+		"skins.hydra.runtime.styles": {
+			"class": "SassAwareResourceLoaderFileModule",
+			"styles": [
+				"resources/hydra.runtime.scss"
+			]
 		}
 	},
 	"ResourceModuleSkinStyles": {


### PR DESCRIPTION
While working on GPUCP-528, the default FlaggedRevs styling made me sad, so I've added some styling for it.

In the process of that I realized we want to have themed colors vars on :root like Oasis does for further compatibility with fandom extensions, so that's also been done.

@Wikia/hydra