### PR TITLE
GPUCP-638 | Make CSS more compatible with ad-engine

### DIFF
--- a/HydraHooks.php
+++ b/HydraHooks.php
@@ -400,7 +400,7 @@ class HydraHooks {
 		}
 
 		// Add body class for advertisement toggling.
-		if ($showAds && self::getAdBySlot('footermrec')) {
+		if ($showAds) {
 			$bodyAttrs['class'] .= ' show-ads';
 		} else {
 			$bodyAttrs['class'] .= ' hide-ads';
@@ -458,30 +458,18 @@ class HydraHooks {
 	 * Should this page show advertisements?
 	 *
 	 * @access public
-	 * @param  object	Skin
+	 * @param  Skin Skin
 	 * @return boolean	Advertisements Visible
 	 */
 	public static function showAds($skin) {
-		global $wgUser;
-
 		if (self::$showAds !== null) {
 			return self::$showAds;
 		}
 
-		$isPremium = false;
-		if (class_exists('\Hydra\Subscription') && !empty($wgUser) && $wgUser->getId()) {
-			$subscription = \Hydra\Subscription::newFromUser($wgUser);
-			if ($subscription !== false) {
-				$isPremium = $subscription->hasSubscription();
-			}
-		}
+		$decider = new AdEngineDecider();
+		$reason = $decider->getNoAdsReason($skin->getContext());
 
-		$action = $skin->getRequest()->getVal('action');
-		$showAds = false;
-		if (!$isPremium && $action != 'edit' && $action != 'submit' && $skin->getRequest()->getVal('veaction') != 'edit' && $skin->getTitle()->getNamespace() != NS_SPECIAL) {
-			$showAds = true;
-		}
-		self::$showAds = $showAds;
+		self::$showAds = ($reason === null);
 
 		return self::$showAds;
 	}
@@ -490,7 +478,7 @@ class HydraHooks {
 	 * Should this page show the ATF MREC Advertisement?
 	 *
 	 * @access public
-	 * @param  object	Skin
+	 * @param  Skin Skin
 	 * @return boolean	Show ATF MREC Advertisement
 	 */
 	public static function showSideRailAPUs($skin) {

--- a/css/advertisements.less
+++ b/css/advertisements.less
@@ -6,28 +6,6 @@
 	width: 300px !important;
 }
 
-#content div#atflb, #content div#btflb {
-	display: block !important;
-	margin: 0 auto;
-	min-height: 66px !important;
-	max-height: 250px !important;
-	min-width: 320px !important;
-	max-width: 970px !important;
-	padding: 5px 0;
-	text-align: center;
-}
-
-div#atflb > iframe, div#btflb > iframe {
-	display: block;
-	margin: 0 auto;
-	min-height: 66px !important;
-	max-height: 250px !important;
-	min-width: 728px !important;
-	max-width: 970px !important;
-	padding: 0;
-	text-align: center;
-}
-
 div#btflb {
 	clear: both;
 }

--- a/resources/banner.scss
+++ b/resources/banner.scss
@@ -13,7 +13,3 @@
 		}
 	}
 }
-
-.banner-notifications-placeholder {
-	margin-bottom: 1em;
-}


### PR DESCRIPTION
Use AdEngineDecider for the showAds function on HydraHooks.

Remove atflb/btflb CSS from advertisements.less; ad-engine will style
these elements properly.  This does make for pop-in when ads load, but
it's nearly impossible to determine the proper height of these elements
from the server, since instant config changes the slot size and bids can
dynamically cause slots to not be shown.

Remove the margin-bottom thing from BannerNotifications css, it was
never doing anything useful, and was just pushing the content down.