### PR TITLE
Make it possible for the skin to work with 1.35

### DIFF
--- a/SkinHydra.php
+++ b/SkinHydra.php
@@ -26,15 +26,6 @@ class SkinHydra extends SkinVector {
 		if (HydraHooks::showAds($this) && $config->get('HydraSkinShowAnchorAd') && !empty(HydraHooks::getAdBySlot('anchor'))) {
 			$out->addModuleScripts('skins.hydra.anchor.apu.js');
 		}
-	}
-
-	/**
-	 * Loads skin and user CSS files.
-	 *
-	 * @param OutputPage $out
-	 */
-	public function setupSkinUserCss(OutputPage $out) {
-		parent::setupSkinUserCss($out);
 
 		$out->addModuleStyles(
 			[


### PR DESCRIPTION
See #17 for background on my goal here.

This code makes it somewhat possible to run this skin on a Vanilla MediaWiki install provided the HydraCore": ">= 3.0.0 dependency is dropped from skin.json

Unfortunately, I hit a snag in that I can't find SassAwareResourceLoaderFileModule anywhere - is this closed source code? If not, could it be published somewhere so I could package it up as an extension and continue with these changes?
